### PR TITLE
Rename remaining time function

### DIFF
--- a/playVideo/VpaidVideoAd.js
+++ b/playVideo/VpaidVideoAd.js
@@ -392,7 +392,7 @@ VpaidVideoPlayer.prototype.getAdHeight = function() {
 /**
  * @return {number} The time remaining in the ad.
  */
-VpaidVideoPlayer.prototype.getRemainingTime = function() {
+VpaidVideoPlayer.prototype.getAdRemainingTime = function() {
   return this.attributes_['remainingTime'];
 };
 


### PR DESCRIPTION
According to the IAB, the expected function is getAdRemainingTime and not getRemainingTime

See https://www.iab.com/wp-content/uploads/2015/06/VPAID_2_0_Final_04-10-2012.pdf